### PR TITLE
Update platform option to be required in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,13 +111,13 @@ Additional app and environment details can be added to the "options" object when
 <pre class="prettyprint">
     var options = {
         appId : MOBILE_ANALYTICS_APP_ID,       //Required e.g. 'c5d69c75a92646b8953126437d92c007'
+        platform : DEVICE_PLATFORM,            //Required valid values: 'Android', 'iPhoneOS', 'WindowsPhone', 'Blackberry', 'Windows', 'MacOS', 'Linux'
         appTitle : APP_TITLE,                  //Optional e.g. 'Example App'
         appVersionName : APP_VERSION_NAME,     //Optional e.g. '1.4.1'
         appVersionCode : APP_VERSION_CODE,     //Optional e.g. '42'
         appPackageName : APP_PACKAGE_NAME,     //Optional e.g. 'com.amazon.example'
         make : DEVICE_MAKE,                    //Optional e.g. 'Amazon'
         model : DEVICE_MODEL,                  //Optional e.g. 'KFTT'
-        platform : DEVICE_PLATFORM,            //Optional valid values: 'Android', 'iPhoneOS', 'WindowsPhone', 'Blackberry', 'Windows', 'MacOS', 'Linux'
         platformVersion : DEVICE_PLATFORM_VER  //Optional e.g. '4.4'
     };
     mobileAnalyticsClient = new AMA.Manager(options);


### PR DESCRIPTION
I wasn't able to get my event data showing up on my mobile analytics - Custom Events tab until I passed in platform variable in my options. 

It seems someone else had the same issue before as well http://brian.jp/post/115260296866/setting-up-aws-mobile-analytics-with-javascript: 

> You see what the documentation fails to mention, at least the time that I read through it, is that you need to send a ‘platform’ as well. If you do not specify a platform, your analytics will end up in /dev/null. Add a platform with either of these values: ’Android’, ‘iOS’, and your analytics should show up within minutes.

Please ignore this PR if this is not right, thanks! :)
